### PR TITLE
Fixes ADS missing XCB on linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
 if (UNIX AND NOT APPLE)
+  find_package(XCB COMPONENTS XCB REQUIRED)
   target_link_libraries(qtadvanceddocking PUBLIC xcb)
 endif()
 set_target_properties(qtadvanceddocking PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,9 @@ endif()
 target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core 
                                                Qt${QT_VERSION_MAJOR}::Gui 
                                                Qt${QT_VERSION_MAJOR}::Widgets)
+if (UNIX AND NOT APPLE)
+  target_link_libraries(qtadvanceddocking PUBLIC xcb)
+endif()
 set_target_properties(qtadvanceddocking PROPERTIES
     AUTOMOC ON
     AUTORCC ON


### PR DESCRIPTION
This fixes a missing include library in ADS for linux builds. Seems it's not fixed on the original repo, but it was described in [this issue](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/issues/270).