### PR TITLE
Standard display of the UI tooltips. 

### DIFF
--- a/src/stylesheets/default.qss
+++ b/src/stylesheets/default.qss
@@ -158,6 +158,13 @@ QToolButton:hover:enabled, ExclusiveUnselButton:hover:enabled {
 	background-color:#636363;
 }
 
+/*===========================================================================
+ * QToolTip
+ *===========================================================================*/
+
+QToolTip{
+  background-color: rgb(60, 60, 60);
+}
 
 /*===========================================================================
 * QtAdvancedDockingSystem


### PR DESCRIPTION
Changes in the UI tooltips display were made to build a standard display, that is based on the Windows 10 dark theme. Now, the display is not dependent on OS or OS theme, being this dark theme the default one. Here are linked the changes in the ads submodule, that is, the addition of the QToolTip into the .qss stylesheet, with the background-color (color of the base of the tooltip) being defined by the rgb function.